### PR TITLE
Log metrics on opening the Breakdown2 App

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,7 +52,10 @@ class SceneBreakdown2(sgtk.platform.Application):
             from sgtk.util.metrics import EventMetric
 
             EventMetric.log(
-                EventMetric.GROUP_APP, "Logged In", log_once=True, bundle=self
+                EventMetric.GROUP_TOOLKIT,
+                "Opened Breakdown2 App",
+                log_once=False,
+                bundle=self,
             )
         except:
             # Ignore all errors, e.g. using a core that does not support metrics.


### PR DESCRIPTION
* Use the 'Toolkit' event group
* Use custom 'Opened Breakdown2 App' event name; this will log as an "Unknown Event" in Amplitude but ensure we have a unique event to log users opening the app
* Log any time a user opens the app (not just once)