### PR TITLE
Register engine command from settings instead of hardcoded.

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ class SceneBreakdown2(sgtk.platform.Application):
 
         # Register a menu entry on the ShotGrid menu so that users can launch the panel.
         self.engine.register_command(
-            "Scene Breakdown...",
+            self.get_setting("display_name"),
             self.create_panel,
             {"type": "panel", "short_name": "breakdown"},
         )


### PR DESCRIPTION
Register engine command with a name from the ``display_name`` setting instead of hardcoded in app.py.