### PR TITLE
Add app_display_mode to choose default launch mode (panel or dialog)

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,23 +36,24 @@ class SceneBreakdown2(sgtk.platform.Application):
 
             # Register a menu entry on the ShotGrid menu so that users can launch the panel.
             self.engine.register_command(
-                self.get_setting("display_name"),
+                "Scene Breakdown...",
                 self.create_panel,
                 {"type": "panel", "short_name": "breakdown"},
             )
 
         elif self.get_setting("app_display_mode") == "dialog":
 
+            # Register the app as a dialog
             # Register a menu entry on the ShotGrid menu so that users can launch the dialog.
             self.engine.register_command(
-                self.get_setting("display_name"),
+                "Scene Breakdown...",
                 lambda: self.create_dialog(),
                 {"type": "dialog", "short_name": "breakdown"},
             )
 
         else:
-            self.logger.error("An invalid app_display_mode was configured. "
-                              "`{}` is not a valid app_display_mode setting!".format(self.get_setting("app_display_mode")))
+            self.logger.error("An invalid app_display_mode was configured. `{}` is not a valid app_display_mode "
+                              "setting!".format(self.get_setting("app_display_mode")))
 
     def show_dialog(self):
         """Show the Scene Breakdown 2 App dialog."""

--- a/app.py
+++ b/app.py
@@ -52,8 +52,10 @@ class SceneBreakdown2(sgtk.platform.Application):
             )
 
         else:
-            self.logger.error("An invalid app_display_mode was configured. `{}` is not a valid app_display_mode "
-                              "setting!".format(self.get_setting("app_display_mode")))
+            self.logger.error(
+                            "An invalid app_display_mode was configured. `{}` is not a valid app_display_mode "
+                            "setting!".format(self.get_setting("app_display_mode"))
+                        )
 
     def show_dialog(self):
         """Show the Scene Breakdown 2 App dialog."""

--- a/app.py
+++ b/app.py
@@ -29,15 +29,30 @@ class SceneBreakdown2(sgtk.platform.Application):
         self._current_dialog = None
         self._current_panel = None
 
-        # Register the app as a panel.
-        self._unique_panel_id = self.engine.register_panel(self.create_panel)
+        if self.get_setting("app_display_mode") == "panel":
 
-        # Register a menu entry on the ShotGrid menu so that users can launch the panel.
-        self.engine.register_command(
-            self.get_setting("display_name"),
-            self.create_panel,
-            {"type": "panel", "short_name": "breakdown"},
-        )
+            # Register the app as a panel.
+            self._unique_panel_id = self.engine.register_panel(self.create_panel)
+
+            # Register a menu entry on the ShotGrid menu so that users can launch the panel.
+            self.engine.register_command(
+                self.get_setting("display_name"),
+                self.create_panel,
+                {"type": "panel", "short_name": "breakdown"},
+            )
+
+        elif self.get_setting("app_display_mode") == "dialog":
+
+            # Register a menu entry on the ShotGrid menu so that users can launch the dialog.
+            self.engine.register_command(
+                self.get_setting("display_name"),
+                lambda: self.create_dialog(),
+                {"type": "dialog", "short_name": "breakdown"},
+            )
+
+        else:
+            self.logger.error("An invalid app_display_mode was configured. "
+                              "`{}` is not a valid app_display_mode setting!".format(self.get_setting("app_display_mode")))
 
     def show_dialog(self):
         """Show the Scene Breakdown 2 App dialog."""

--- a/hooks/tk-maya_scene_operations.py
+++ b/hooks/tk-maya_scene_operations.py
@@ -48,7 +48,7 @@ class BreakdownSceneOperations(HookBaseClass):
         refs = []
 
         # first let's look at maya references
-        for ref in cmds.file(q=True, reference=True):
+        for ref in cmds.file(query=True, reference=True):
             node_name = cmds.referenceQuery(ref, referenceNode=True)
 
             # get the path and make it platform dependent

--- a/info.yml
+++ b/info.yml
@@ -10,6 +10,11 @@
 
 configuration:
 
+    app_display_mode:
+        type: str
+        default_value: panel
+        description: Specify if the app should launch as `panel` or `dialog`.  Not all engines support panels.
+
     hook_scene_operations:
         type: hook
         default_value: "{self}/{engine_name}_scene_operations.py"


### PR DESCRIPTION
This pull request adds an app setting `app_display_mode` which allows us to set how the app launches, in dialog mode or panel mode.

The way that a panel spawns in software like Houdini can make it cumbersome to use (the panel spawns collapsed into a sidebar).
If we prefer a dialog this is now possible.