### PR TITLE
Register display name from settings instead of hardcoding

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ class SceneBreakdown2(sgtk.platform.Application):
 
         # Register a menu entry on the ShotGrid menu so that users can launch the panel.
         self.engine.register_command(
-            "Scene Breakdown...",
+            self.get_setting("display_name"),
             self.create_panel,
             {"type": "panel", "short_name": "breakdown"},
         )

--- a/app.py
+++ b/app.py
@@ -34,9 +34,9 @@ class SceneBreakdown2(sgtk.platform.Application):
 
         # Register a menu entry on the ShotGrid menu so that users can launch the panel.
         self.engine.register_command(
-            self.get_setting("display_name"),
+            "{}...".format(self.get_setting("display_name")),
             self.create_panel,
-            {"type": "panel", "short_name": "breakdown"},
+            {"type": "panel", "short_name": "breakdown2"},
         )
 
     def show_dialog(self):
@@ -77,7 +77,7 @@ class SceneBreakdown2(sgtk.platform.Application):
         try:
             widget = self.engine.show_panel(
                 self._unique_panel_id,
-                "Scene Breakdown",
+                self.get_setting("display_name"),
                 self,
                 tk_multi_breakdown2.AppDialog,
             )

--- a/info.yml
+++ b/info.yml
@@ -10,6 +10,11 @@
 
 configuration:
 
+    display_name:
+        type: str
+        default_value: Scene Breakdown2
+        description: Specify a name for the app, it's menu item and the ui.
+
     hook_scene_operations:
         type: hook
         default_value: "{self}/{engine_name}_scene_operations.py"

--- a/info.yml
+++ b/info.yml
@@ -12,7 +12,7 @@ configuration:
 
     display_name:
         type: str
-        default_value: Scene Breakdown2
+        default_value: Scene Breakdown
         description: Specify a name for the app, it's menu item and the ui.
 
     hook_scene_operations:

--- a/python/tk_multi_breakdown2/__init__.py
+++ b/python/tk_multi_breakdown2/__init__.py
@@ -29,4 +29,4 @@ def show_dialog(app):
     :rtype: AppDialog
     """
 
-    return app.engine.show_dialog("Scene Breakdown", app, AppDialog)
+    return app.engine.show_dialog(app.get_setting("display_name"), app, AppDialog)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -112,11 +112,11 @@ class TestApplication(AppTestBase):
 
         # Ensure that the engine has the app command registered with
         # the correct properties
-        app_cmd = self.engine.commands.get("Scene Breakdown...", None)
+        app_cmd = self.engine.commands.get("Scene Breakdown2...", None)
         assert app_cmd is not None
         cmd_props = app_cmd.get("properties", None)
         assert cmd_props is not None
-        assert cmd_props.get("short_name", "") == "breakdown"
+        assert cmd_props.get("short_name", "") == "breakdown2"
 
     def test_app_hooks_exist(self):
         """

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -112,11 +112,11 @@ class TestApplication(AppTestBase):
 
         # Ensure that the engine has the app command registered with
         # the correct properties
-        app_cmd = self.engine.commands.get("Scene Breakdown2...", None)
+        app_cmd = self.engine.commands.get("Scene Breakdown...", None)
         assert app_cmd is not None
         cmd_props = app_cmd.get("properties", None)
         assert cmd_props is not None
-        assert cmd_props.get("short_name", "") == "breakdown2"
+        assert cmd_props.get("short_name", "") == "breakdown"
 
     def test_app_hooks_exist(self):
         """


### PR DESCRIPTION
Reopening this pull request.

**Changes:**
- Renamed app commands to `breakdown2` since naming it `breakdown` seems to cause conflicts with the older breakdown app in case both are used in the same engine config.
- Added `display_name` setting to rename the app as desired
- Changed unit tests to reflect changes in command name and display name.
- The default `display_name` is `Scene Breakdown2`. When registering the panel the registration will register `{display_name}` and append three dots as is usual for Toolkit apps, resulting in `{display_name}...`.