### PR TITLE
Update file_item_model.py

### DIFF
--- a/python/tk_multi_breakdown2/file_item_model.py
+++ b/python/tk_multi_breakdown2/file_item_model.py
@@ -1630,7 +1630,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
             self._finish_reload()
 
 
-class FileModelItem:
+class FileModelItem(object):
     """Data structure to hold information about an item in the Layer model."""
 
     def __init__(self, file_item):


### PR DESCRIPTION
Make FileModelItem python-2 compatible.

In the current implementation the class `FileModelItem `will be interpreted by python-2 as an old-style class.
This makes it incompatibe to the super call in [`FileTreeModelItem`](https://github.com/shotgunsoftware/tk-multi-breakdown2/blob/master/python/tk_multi_breakdown2/file_item_model.py#L1704).

Declating it as new-style python-2 class will fix errors. Tested in Maya 2022 - python-2.