### PR TITLE
Add setting to allow history published files to be filtered

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -65,6 +65,17 @@ configuration:
           - [task, is_not, null]
           - [entity, is_not, null]
 
+    history_published_file_filters:
+        type: list
+        description: List of filters that will be applied when querying ShotGrid for the historyPublished Files
+                     based on the items found in the scene. To show Published Files without a Task, remove the
+                     default filter to exclude Published Files that do not have a Task, and similarly for
+                     Link entity.
+        values:
+            type: shotgun_filter
+        allows_empty: True
+        default_value: []
+
     group_by:
         type: str
         default_value: project

--- a/python/tk_multi_breakdown2/api/manager.py
+++ b/python/tk_multi_breakdown2/api/manager.py
@@ -107,7 +107,7 @@ class BreakdownManager(object):
         # No background task manager provided, execute the request synchronously and return
         # the published files data immediately.
         return sgtk.util.find_publish(
-            self._bundle.sgtk, file_paths, fields=fields, only_current_project=False
+            self._bundle.sgtk, file_paths, filters=filters, fields=fields, only_current_project=False
         )
 
     def get_file_items(self, scene_objects, published_files):

--- a/python/tk_multi_breakdown2/api/manager.py
+++ b/python/tk_multi_breakdown2/api/manager.py
@@ -264,6 +264,8 @@ class BreakdownManager(object):
             ["published_file_type", "is", item.sg_data["published_file_type"]],
         ]
 
+        filters.extend(self.get_published_file_filters())
+
         pfs = self._bundle.shotgun.find(
             "PublishedFile",
             filters=filters,

--- a/python/tk_multi_breakdown2/file_history_model.py
+++ b/python/tk_multi_breakdown2/file_history_model.py
@@ -164,6 +164,8 @@ class FileHistoryModel(ShotgunModel, ViewItemRolesMixin):
             ["entity", "is", self.parent_entity["entity"]],
             ["published_file_type", "is", self.parent_entity["published_file_type"]],
         ]
+        # get extra filters from the app settings
+        filters.extend(self._app.get_setting("history_published_file_filters", []))
 
         ShotgunModel._load_data(
             self,


### PR DESCRIPTION
As described in [this issue](https://github.com/shotgunsoftware/tk-multi-breakdown2/issues/73), this code exposes a new setting to allow filtering the history of published files. This is useful to filter the displayed historic published files and only allow the artist to be able to use certain pre-filtered published files.