### PR TITLE
SHOT-4354: API backward compatibility fix

### DIFF
--- a/python/tk_multi_breakdown2/api/manager.py
+++ b/python/tk_multi_breakdown2/api/manager.py
@@ -59,7 +59,7 @@ class BreakdownManager(object):
 
         # Execute in the current thread
         return self._bundle.execute_hook_method("hook_scene_operations", "scan_scene")
-        
+
     @sgtk.LogManager.log_timing
     def scan_scene(self, extra_fields=None, execute_in_main_thread=True):
         """
@@ -77,9 +77,13 @@ class BreakdownManager(object):
         :rtype: List[FileItem]
         """
 
-        scene_objects = self.get_scene_objects(execute_in_main_thread=execute_in_main_thread)
+        scene_objects = self.get_scene_objects(
+            execute_in_main_thread=execute_in_main_thread
+        )
         file_paths = [o["path"] for o in scene_objects]
-        published_files = self.get_published_files_from_file_paths(file_paths, extra_fields=extra_fields)
+        published_files = self.get_published_files_from_file_paths(
+            file_paths, extra_fields=extra_fields
+        )
         return self.get_file_items(scene_objects, published_files)
 
     @sgtk.LogManager.log_timing
@@ -130,7 +134,11 @@ class BreakdownManager(object):
         # No background task manager provided, execute the request synchronously and return
         # the published files data immediately.
         return sgtk.util.find_publish(
-            self._bundle.sgtk, file_paths, filters=filters, fields=fields, only_current_project=False
+            self._bundle.sgtk,
+            file_paths,
+            filters=filters,
+            fields=fields,
+            only_current_project=False,
         )
 
     def get_file_items(self, scene_objects, published_files):

--- a/python/tk_multi_breakdown2/api/manager.py
+++ b/python/tk_multi_breakdown2/api/manager.py
@@ -130,7 +130,7 @@ class BreakdownManager(object):
         # No background task manager provided, execute the request synchronously and return
         # the published files data immediately.
         return sgtk.util.find_publish(
-            self._bundle.sgtk, file_paths, fields=fields, only_current_project=False
+            self._bundle.sgtk, file_paths, filters=filters, fields=fields, only_current_project=False
         )
 
     def get_file_items(self, scene_objects, published_files):

--- a/python/tk_multi_breakdown2/file_item_model.py
+++ b/python/tk_multi_breakdown2/file_item_model.py
@@ -693,7 +693,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
 
             # Run the scan scene method in the main thread (not a background task) since this
             # may cause issues for certain DCCs
-            self.__scene_objects = self._manager.scan_scene()
+            self.__scene_objects = self._manager.get_scene_objects()
 
             # Make an async request to get the published files for the references in the scene.
             # This will omit any objects from the scene that do not have a ShotGrid Published

--- a/tests/test_api_manager.py
+++ b/tests/test_api_manager.py
@@ -189,6 +189,45 @@ def bundle(bundle_settings, bundle_hook_methods):
 
 
 @pytest.mark.parametrize("execute_in_main_thread", [None, True, False])
+def test_get_scene_objects(
+    bundle,
+    find_publish_return_value,
+    bundle_hook_scan_scene_return_value,
+    execute_in_main_thread,
+):
+    """
+    Test the BreakdownManager 'get_scene_objects' method. This test case aims to strictly test
+    the functionality of the BreakdownManager, and not the data returned by the hooks
+    or Shotgun query.
+    """
+
+    manager = BreakdownManager(bundle)
+
+    # Patch the method call 'sgtk.util.find_publish' in the BreakdownManager get_scene_objects to
+    # return the mock data 'find_publish_return_value'.
+    with patch("sgtk.util.find_publish", return_value=find_publish_return_value):
+        # Call the method that is to be tested.
+        if execute_in_main_thread is None:
+            scene_items = manager.get_scene_objects()
+        else:
+            scene_items = manager.get_scene_objects(
+                execute_in_main_thread=execute_in_main_thread
+            )
+
+    # Assert the result return type.
+    assert isinstance(scene_items, list)
+
+    # Assert that the scene items are of the right type and have the expected data.
+    for index, item in enumerate(scene_items):
+        assert isinstance(item, dict)
+
+        expected_scene_item = bundle_hook_scan_scene_return_value[index]
+        assert item.get("node_name") == expected_scene_item["node_name"]
+        assert item.get("node_type") == expected_scene_item["node_type"]
+        assert item.get("extra_data") == expected_scene_item.get("extra_data")
+
+
+@pytest.mark.parametrize("execute_in_main_thread", [None, True, False])
 def test_scan_scene(
     bundle,
     find_publish_return_value,
@@ -219,13 +258,12 @@ def test_scan_scene(
 
     # Assert that the scene items are of the right type and have the expected data.
     for index, item in enumerate(scene_items):
-        # assert isinstance(item, FileItem)
-        assert isinstance(item, dict)
+        assert isinstance(item, FileItem)
 
         expected_scene_item = bundle_hook_scan_scene_return_value[index]
-        assert item.get("node_name") == expected_scene_item["node_name"]
-        assert item.get("node_type") == expected_scene_item["node_type"]
-        assert item.get("extra_data") == expected_scene_item.get("extra_data")
+        assert item.node_name == expected_scene_item["node_name"]
+        assert item.node_type == expected_scene_item["node_type"]
+        assert item.extra_data == expected_scene_item.get("extra_data")
 
 
 @pytest.mark.parametrize(
@@ -618,10 +656,10 @@ class TestBreakdownManager(AppTestBase):
                 {"id": pf["id"], "project": pf["project"]}
             )
 
-    def test_scan_scene(self):
+    def test_get_scene_objects(self):
         """Test scanning the current scene."""
 
-        scene_items = self.manager.scan_scene()
+        scene_items = self.manager.get_scene_objects()
         assert isinstance(scene_items, list)
 
         file_paths = [item["path"] for item in scene_items]
@@ -629,6 +667,46 @@ class TestBreakdownManager(AppTestBase):
         assert len(published_files) == len(self.expected_published_files_found)
 
         file_items = self.manager.get_file_items(scene_items, published_files)
+
+        fields = self.constants.PUBLISHED_FILES_FIELDS + self.app.get_setting(
+            "published_file_fields", []
+        )
+
+        found_paths = []
+        found_published_files = []
+        for item in file_items:
+            assert hasattr(item, "sg_data")
+            assert isinstance(item.sg_data, dict)
+            assert item.sg_data is not None
+
+            sg_data_keys = item.sg_data.keys()
+            for field in fields:
+                assert field in sg_data_keys
+
+            found_paths.append(item.path)
+            found_published_files.append(
+                {"id": item.sg_data["id"], "project": item.sg_data["project"]}
+            )
+
+        # Assert that all expected paths were found.
+        assert set(found_paths) == set(self.expected_published_file_paths)
+        # Assert that all the expected published files were found, and no unexpected files were found.
+        assert [
+            pf
+            for pf in found_published_files
+            if pf not in self.expected_published_files_found
+        ] == []
+        assert [
+            pf
+            for pf in self.expected_published_files_found
+            if pf not in found_published_files
+        ] == []
+
+    def test_scan_scene(self):
+        """Test scanning the current scene."""
+
+        file_items = self.manager.scan_scene()
+        assert isinstance(file_items, list)
 
         fields = self.constants.PUBLISHED_FILES_FIELDS + self.app.get_setting(
             "published_file_fields", []
@@ -677,20 +755,14 @@ class TestBreakdownManager(AppTestBase):
             ["one_field", "two fields", "some field"],
         ]
         for extra_fields in possible_extra_fields:
-            scene_items = self.manager.scan_scene(extra_fields)
-            assert isinstance(scene_items, list)
+            file_items = self.manager.scan_scene(extra_fields)
+            assert isinstance(file_items, list)
 
             fields = self.constants.PUBLISHED_FILES_FIELDS + self.app.get_setting(
                 "published_file_fields", []
             )
             if extra_fields:
                 fields += extra_fields
-
-            file_paths = [item["path"] for item in scene_items]
-            published_files = self.manager.get_published_files_from_file_paths(
-                file_paths, extra_fields=extra_fields
-            )
-            file_items = self.manager.get_file_items(scene_items, published_files)
 
             found_paths = []
             found_published_files = []
@@ -725,18 +797,9 @@ class TestBreakdownManager(AppTestBase):
     def test_get_latest_published_file(self):
         """Test getting the latest available published file according to the current item context."""
 
-        scene_items = self.manager.scan_scene()
-        file_paths = [item["path"] for item in scene_items]
-
-        published_files = self.manager.get_published_files_from_file_paths(
-            file_paths,
-        )
-        assert isinstance(published_files, dict)
-        for file_path in published_files:
-            assert file_path in file_paths
-
-        file_items = self.manager.get_file_items(scene_items, published_files)
+        file_items = self.manager.scan_scene()
         assert isinstance(file_items, list)
+
         try:
             item = next(
                 i
@@ -761,20 +824,15 @@ class TestBreakdownManager(AppTestBase):
     def test_get_published_file_history(self):
         """Test getting the published history for the selected item."""
 
-        scene_items = self.manager.scan_scene()
-        assert isinstance(scene_items, list)
+        file_items = self.manager.scan_scene()
+        assert isinstance(file_items, list)
 
         # Use any item from the scene
         try:
-            scene_item = scene_items[0]
+            item = file_items[0]
         except IndexError:
             # Test data is invalid, expected that scan scene would return at least one item.
             raise InvalidTestData("Expected result to have at least one item.")
-
-        published_files = self.manager.get_published_files_from_file_paths(
-            [scene_item["path"]],
-        )
-        item = self.manager.get_file_items([scene_item], published_files)[0]
 
         latest_published_file_before_update = item.latest_published_file
         result = self.manager.get_published_file_history(item)
@@ -806,20 +864,15 @@ class TestBreakdownManager(AppTestBase):
         Test getting the published history for the selected item.
         """
 
-        scene_items = self.manager.scan_scene()
-        assert isinstance(scene_items, list)
+        file_items = self.manager.scan_scene()
+        assert isinstance(file_items, list)
 
         # Use any item from the scene
         try:
-            scene_item = scene_items[0]
+            item = file_items[0]
         except IndexError:
             # Test data is invalid, expected that scan scene would return at least one item.
             raise InvalidTestData("Expected result to have at least one item.")
-
-        published_files = self.manager.get_published_files_from_file_paths(
-            [scene_item["path"]],
-        )
-        item = self.manager.get_file_items([scene_item], published_files)[0]
 
         latest_published_file_before_update = item.latest_published_file
         possible_extra_fields = [
@@ -858,20 +911,15 @@ class TestBreakdownManager(AppTestBase):
         Test the Breakdown Manager 'update_to_latest_version' method.
         """
 
-        scene_items = self.manager.scan_scene()
-        assert isinstance(scene_items, list)
+        file_items = self.manager.scan_scene()
+        assert isinstance(file_items, list)
 
         # Use any item from the scene
         try:
-            scene_item = scene_items[0]
+            item = file_items[0]
         except IndexError:
             # Test data is invalid, expected that scan scene would return at least one item.
             raise InvalidTestData("Expected result to have at least one item.")
-
-        published_files = self.manager.get_published_files_from_file_paths(
-            [scene_item["path"]]
-        )
-        item = self.manager.get_file_items([scene_item], published_files)[0]
 
         if item.sg_data is None:
             expected_latest_data = {"version_number": 1}
@@ -902,14 +950,10 @@ class TestBreakdownManager(AppTestBase):
     def test_update_to_specific_version(self):
         """Test the Breakdown Manager 'update_to_latest_version' method."""
 
-        scene_items = self.manager.scan_scene()
-        assert isinstance(scene_items, list)
+        file_items = self.manager.scan_scene()
+        assert isinstance(file_items, list)
         # Make sure there is data to be tested
-        assert len(scene_items) > 0
-
-        file_paths = [item["path"] for item in scene_items]
-        published_files = self.manager.get_published_files_from_file_paths(file_paths)
-        file_items = self.manager.get_file_items(scene_items, published_files)
+        assert len(file_items) > 0
 
         # Use any scene item that has a history
         item = None
@@ -971,6 +1015,16 @@ class TestBreakdownManagerMultipleProjects(TestBreakdownManager):
         # Create a second project for the test module
         _, project2_root = self.create_project({"name": "project 2"})
 
+        # Create Task and Entity objects for the published files
+        task1 = {"id": 900, "type": "Task", "content": "Task project 2 publish 1"}
+        self.add_to_sg_mock_db(task1)
+        task2 = {"id": 901, "type": "Task", "content": "Task project 2 publish 2"}
+        self.add_to_sg_mock_db(task2)
+        asset1 = {"id": 900, "type": "Asset", "code": "Asset project 2 publish 1"}
+        self.add_to_sg_mock_db(asset1)
+        asset2 = {"id": 900, "type": "Asset", "code": "Asset project 2 publish 2"}
+        self.add_to_sg_mock_db(asset2)
+
         # Add the new project path to the environment variable
         os.environ["TK_TEST_PROJECT_ROOT_PATHS"] += "," + project2_root
 
@@ -988,6 +1042,8 @@ class TestBreakdownManagerMultipleProjects(TestBreakdownManager):
             },
             created_at=datetime.datetime(2021, 1, 4, 12, 1),
             version_number=4,
+            task=task1,
+            entity=asset1,
         )
         project2_publish2 = self.create_published_file(
             code="abc2",
@@ -1001,6 +1057,8 @@ class TestBreakdownManagerMultipleProjects(TestBreakdownManager):
             },
             created_at=datetime.datetime(2021, 1, 4, 12, 1),
             version_number=5,
+            task=task2,
+            entity=asset2,
         )
 
         # Add to the list of published files


### PR DESCRIPTION
Fix breaking api change to method `BreakdownManager::scan_scene`. This method was refactored to allow the file model to execute the scan scene in incremental steps to improve performance, but the return value was changed from List[FileItem] to List[dict]. This PR reverts this api breaking change.

This fixes Apps that use the Breakdown2 api:
- tk-multi-scenebuilder 
- tk-multi-workfiles2 (feature that is on turned on via config)

Changes:
* `scan_scene` should return a list of `FileItem` objects (as it did before)
* Add new method `get_scene_objects` to get the scene objects as a list of dicts
* Fix missing filters passed to SG query when not using BG task manager
* Update unit tests