### PR TITLE
SHOT-4378:  Add config option to specify reference update requires user interaction

### DIFF
--- a/hooks/tk-vred_scene_operations.py
+++ b/hooks/tk-vred_scene_operations.py
@@ -265,7 +265,7 @@ class BreakdownSceneOperations(HookBaseClass):
             if r.getObjectId() == ref_id:
                 return r
         return None
-    
+
     def __load_source_references(self, refs, show_options=False):
         """Load the source references in VRED."""
 

--- a/info.yml
+++ b/info.yml
@@ -20,6 +20,13 @@ configuration:
         default_value: True
         description: Specify if the app window should launch as panel or dialog.
 
+    interactive_update:
+        type: bool
+        default_value: False
+        description: Specify if user interaction is required when updating a
+                     reference. This is helpful if a DCC requires user
+                     interaction to specify any update options.
+
     hook_scene_operations:
         type: hook
         default_value: "{self}/{engine_name}_scene_operations.py"


### PR DESCRIPTION
* Add a config option that specifies if reference updates require user interaction
* Add option for VRED users to show the options dialog before reference update in case they need to change anything