### PR TITLE
SG-37246 Fix freeze when interacting with Breakdown scene items

### DIFF
--- a/python/tk_multi_breakdown2/dialog.py
+++ b/python/tk_multi_breakdown2/dialog.py
@@ -690,7 +690,6 @@ class AppDialog(QtGui.QWidget):
         delegate.subtitle_role = FileModel.VIEW_ITEM_SUBTITLE_ROLE
         delegate.thumbnail_role = FileModel.VIEW_ITEM_THUMBNAIL_ROLE
         delegate.icon_role = FileModel.VIEW_ITEM_ICON_ROLE
-        delegate.expand_role = FileModel.VIEW_ITEM_EXPAND_ROLE
         delegate.height_role = FileModel.VIEW_ITEM_HEIGHT_ROLE
         delegate.loading_role = FileModel.VIEW_ITEM_LOADING_ROLE
         delegate.separator_role = FileModel.VIEW_ITEM_SEPARATOR_ROLE

--- a/python/tk_multi_breakdown2/dialog.py
+++ b/python/tk_multi_breakdown2/dialog.py
@@ -711,9 +711,11 @@ class AppDialog(QtGui.QWidget):
                     "show_always": True,
                     "padding": 0,
                     "features": QtGui.QStyleOptionButton.Flat,
-                    "get_data": get_thumbnail_header_status_action_data
-                    if thumbnail
-                    else get_status_action_data,
+                    "get_data": (
+                        get_thumbnail_header_status_action_data
+                        if thumbnail
+                        else get_status_action_data
+                    ),
                 },
             ],
             ViewItemDelegate.LEFT,

--- a/python/tk_multi_breakdown2/file_item_model.py
+++ b/python/tk_multi_breakdown2/file_item_model.py
@@ -60,6 +60,8 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
         NEXT_AVAILABLE_ROLE,  # Keep track of the next available custome role. Insert new roles above.
     ) = range(_BASE_ROLE, _BASE_ROLE + 16)
 
+    FILE_ITEM_EXPAND_ROLE = _BASE_ROLE + 21
+
     # File item status enum
     (
         STATUS_NONE,  # Status is none when the necessary data has not all loaded yet to determine the status
@@ -327,6 +329,9 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
             # It is a file item
             file_item = model_item.file_item
 
+            if role == FileTreeItemModel.FILE_ITEM_EXPAND_ROLE:
+                return model_item.expanded if hasattr(model_item, "expanded") else False
+
             if role == QtCore.Qt.DisplayRole:
                 return file_item.sg_data.get("name") or file_item.node_name
 
@@ -506,6 +511,14 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
 
         changed = False
         change_roles = [role]
+
+        if role == FileTreeItemModel.FILE_ITEM_EXPAND_ROLE:
+            if model_item.expanded == value:
+                return False
+
+            model_item.expanded = value
+            self.dataChanged.emit(index, index, change_roles)
+            return True
 
         if role == QtCore.Qt.DecorationRole:
             model_item.set_thumbnail(value)
@@ -1566,6 +1579,8 @@ class FileModelItem:
 
     def __init__(self, file_item):
         """Initialize the file item."""
+
+        self.expanded = False
 
         self.set_file_item(file_item)
 

--- a/python/tk_multi_breakdown2/file_item_model.py
+++ b/python/tk_multi_breakdown2/file_item_model.py
@@ -60,8 +60,6 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
         NEXT_AVAILABLE_ROLE,  # Keep track of the next available custome role. Insert new roles above.
     ) = range(_BASE_ROLE, _BASE_ROLE + 16)
 
-    FILE_ITEM_EXPAND_ROLE = _BASE_ROLE + 21
-
     # File item status enum
     (
         STATUS_NONE,  # Status is none when the necessary data has not all loaded yet to determine the status
@@ -329,9 +327,6 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
             # It is a file item
             file_item = model_item.file_item
 
-            if role == FileTreeItemModel.FILE_ITEM_EXPAND_ROLE:
-                return model_item.expanded if hasattr(model_item, "expanded") else False
-
             if role == QtCore.Qt.DisplayRole:
                 return file_item.sg_data.get("name") or file_item.node_name
 
@@ -511,14 +506,6 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
 
         changed = False
         change_roles = [role]
-
-        if role == FileTreeItemModel.FILE_ITEM_EXPAND_ROLE:
-            if model_item.expanded == value:
-                return False
-
-            model_item.expanded = value
-            self.dataChanged.emit(index, index, change_roles)
-            return True
 
         if role == QtCore.Qt.DecorationRole:
             model_item.set_thumbnail(value)
@@ -1579,8 +1566,6 @@ class FileModelItem:
 
     def __init__(self, file_item):
         """Initialize the file item."""
-
-        self.expanded = False
 
         self.set_file_item(file_item)
 

--- a/tests/test_api_manager.py
+++ b/tests/test_api_manager.py
@@ -13,7 +13,7 @@ import datetime
 import os
 import sys
 import pytest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from app_test_base import AppTestBase
 


### PR DESCRIPTION
### **Description**

Fixes a freeze issue in Houdini when interacting with the Breakdown view. The problem was triggered by dynamic item height changes caused by the **expand_role** assignment in the delegate. Removing this assignment avoids triggering unnecessary updates, preventing the freeze while maintaining the current visual behavior of the view.

### **Tests**

https://github.com/user-attachments/assets/06614bfe-4c19-453c-98c0-7eb76904c1d0


