### PR TITLE
SG-43664 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 26.1.0
+    rev: 26.5.1
     hooks:
     - id: black
       language_version: python3

--- a/info.yml
+++ b/info.yml
@@ -138,6 +138,7 @@ description: "Tools to manage referenced PublishedFiles in your scene."
 requires_shotgun_version: "v8.20.0"
 requires_core_version: "v0.20.6"
 requires_engine_version:
+minimum_python_version: "3.9"
 
 # Supported Engines
 supported_engines:

--- a/python/tk_multi_breakdown2/actions.py
+++ b/python/tk_multi_breakdown2/actions.py
@@ -205,7 +205,7 @@ class UpdateToSpecificVersionAction(Action):
         :type model: QtGui.QStandardItemModel
         """
 
-        super(UpdateToSpecificVersionAction, self).__init__(label, [file_item], model)
+        super().__init__(label, [file_item], model)
         self._sg_data = sg_data
 
     @wait_cursor


### PR DESCRIPTION
## Summary
- Set `minimum_python_version: "3.9"` in `info.yml`
- Modernised `super()` call in `python/tk_multi_breakdown2/actions.py`

## Test plan
- [ ] Pre-commit passes (black, check-ast, check-yaml, whitespace)
- [ ] Existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)